### PR TITLE
winloop 0.3.1: add py314 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 # Ignore all files and folders in root
 *
+!abs.yaml
 !/conda-forge.yml
 
 # Don't ignore any files/folders if the parent folder is 'un-ignored'

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "winloop" %}
-{% set version = "0.2.2" %}
+{% set version = "0.3.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: b967a8bcc45cb9a6845e5d4fc77a493b8b9928b44b9230ff336b9b10ae399132
+  sha256: f86af8fa3f853bdbdb2b441f856cda7ec6e84a68f82636db34e54709ebcf0a7c
   patches:
     - patches/0001-unvendor-libuv.patch
 
@@ -22,11 +22,11 @@ requirements:
     - {{ stdlib('c') }}
   host:
     - python
+    - cython >=3.1.4
+    - libuv {{ libuv }}
+    - pip
     - setuptools >=60
     - wheel
-    - cython >=3.1.2
-    - pip
-    - libuv {{ libuv }}
   run:
     - python
     - libuv
@@ -63,7 +63,7 @@ test:
   requires:
     - pip
     - pytest
-    - pyopenssl >=23.0,<25.2
+    - pyopenssl >=23.0,<25.4
 
 about:
   home: https://github.com/Vizonex/Winloop


### PR DESCRIPTION
**Destination channel:** Defaults

### Links

- [PKG-10495](https://anaconda.atlassian.net/browse/PKG-10495)
- dev_url:        https://github.com/Vizonex/Winloop/releases/tag/v0.3.1
- conda_forge:    https://github.com/conda-forge/winloop-feedstock
- pypi:           https://pypi.org/project/winloop/0.3.1
- pypi inspector: https://inspector.pypi.io/project/winloop/0.3.1

### Explanation of changes:

- Sort dependencies.
- Update `cython` and `pyopenssl` pinnings to support py314
- Add `!abs.yaml` to `.gitignore`

[PKG-10495]: https://anaconda.atlassian.net/browse/PKG-10495?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ